### PR TITLE
パン屑リストの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,4 @@ gem 'payjp'
 gem "aws-sdk-s3", require: false
 gem "rails-i18n"
 gem 'ransack'
+gem 'gretel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,9 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    gretel (4.4.0)
+      actionview (>= 5.1, < 7.1)
+      railties (>= 5.1, < 7.1)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
@@ -328,6 +331,7 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  gretel
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)

--- a/app/views/cards/new.html.erb
+++ b/app/views/cards/new.html.erb
@@ -1,6 +1,7 @@
 <%= form_with  url: cards_path, id: 'charge-form', class: 'card-form', local: true do |f| %>
   <%# カード情報の入力 %>
   <div class='credit-card-form'>
+  <% breadcrumb :new_card %>
     <h1 class='info-input-haedline'>
       クレジットカード情報入力
     </h1>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,4 +1,6 @@
 <%= render "shared/header" %>
+<p><%= link_to "出品へ", new_item_path %></p>
+<% breadcrumb :root %>
 <div class='main'>
 
   <%# 画面上部の「人生を変えるフリマアプリ」帯部分 %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,6 +1,8 @@
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <p><%= link_to "カード登録へ", cards_new_path %></p>
+    <% breadcrumb :new_items %>
 
   </header>
   <div class="items-sell-main">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
 </head>
 
 <body>
+  <%= breadcrumbs separator: " &rsaquo; " %>
   <%= yield %>
 </body>
 

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,38 @@
+crumb :root do
+  link "Home", root_path
+end
+
+crumb :new_items do
+  link "商品出品", new_item_path
+  parent :root
+end
+
+crumb :new_card do
+  link "カード登録", new_card_path
+  parent :new_items
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
# What
パン屑リストの実装
# Why
今後アプリの追加実装を重ねて、階層が深くなった時に、
ユーザーが現在地を把握しやすくするため。